### PR TITLE
Add two-pass encoding

### DIFF
--- a/discord-video.bat
+++ b/discord-video.bat
@@ -30,7 +30,7 @@ set /A SHOULD_BITRATE=%VIDEO_BITRATE% + %AUDIO_BITRATE%
 
 echo video should have a bitrate of %SHOULD_BITRATE% kbps
 
-ffmpeg -hide_banner -y -i "%~1" -c:v libx264 -preset slower -b:v "%VIDEO_BITRATE%" -vf scale=1280:720 -pass 1 -an -f mp4 NUL && ffmpeg -hide_banner -i "%~1" -c:v libx264 -preset slower -b:v "%VIDEO_BITRATE%" -vf scale=1280:720 -pass 2 -c:a aac -b:a "%AUDIO_BITRATE%" "%~1-compressed.mp4"
+ffmpeg -hide_banner -i "%~1" -c:v libvpx-vp9 -row-mt 1 -b:v "%VIDEO_BITRATE%" -pix_fmt yuv420p -vf scale=1280:720 -pass 1 -an -f null NUL && ffmpeg -hide_banner -i "%~1" -c:v libvpx-vp9 -cpu-used 3 -row-mt 1 -b:v "%VIDEO_BITRATE%" -pix_fmt yuv420p -vf scale=1280:720  -c:a libopus -b:a "%AUDIO_BITRATE%" -pass 2 "%~1-compressed.mp4"
 
 goto end
 

--- a/discord-video.bat
+++ b/discord-video.bat
@@ -24,13 +24,13 @@ for /f "tokens=1,2 delims=." %%a  in ("%var%") do (
 
 set /a rounded=%first_part%
 
-set /A VIDEO_BITRATE=%MAX_VIDEO_SIZE% / %rounded% * 60 / 100
-set /A AUDIO_BITRATE=%MAX_AUDIO_SIZE% / %rounded% * 75 / 100
-set /A SHOULD_BITRATE=(%MAX_SIZE% / %rounded%)/1000
+set /A VIDEO_BITRATE=%MAX_VIDEO_SIZE% / %rounded%
+set /A AUDIO_BITRATE=%MAX_AUDIO_SIZE% / %rounded%
+set /A SHOULD_BITRATE=%VIDEO_BITRATE% + %AUDIO_BITRATE%
 
 echo video should have a bitrate of %SHOULD_BITRATE% kbps
 
-ffmpeg -hide_banner -i "%~1" -c:v libvpx-vp9 -b:v "%VIDEO_BITRATE%" -vf scale=1280:720 -c:a libopus -b:a "%AUDIO_BITRATE%" "%~1-compressed.webm"
+ffmpeg -hide_banner -y -i "%~1" -c:v libx264 -preset slower -b:v "%VIDEO_BITRATE%" -vf scale=1280:720 -pass 1 -an -f mp4 NUL && ffmpeg -hide_banner -i "%~1" -c:v libx264 -preset slower -b:v "%VIDEO_BITRATE%" -vf scale=1280:720 -pass 2 -c:a aac -b:a "%AUDIO_BITRATE%" "%~1-compressed.mp4"
 
 goto end
 

--- a/discord-video.sh
+++ b/discord-video.sh
@@ -27,7 +27,8 @@ echo "$1" is a video file and is $DURATION seconds long
 # Calculate bitrate
 
 ADJUSTED_DURATION=$(printf "%.0f\n" "$DURATION")
-VIDEO_BITRATE=$(echo $((MAX_VIDEO_SIZE / ADJUSTED_DURATION*60/100)))
-AUDIO_BITRATE=$(echo $((MAX_AUDIO_SIZE / ADJUSTED_DURATION*75/100)))
+VIDEO_BITRATE=$(echo $((MAX_VIDEO_SIZE / ADJUSTED_DURATION)))
+AUDIO_BITRATE=$(echo $((MAX_AUDIO_SIZE / ADJUSTED_DURATION)))
 
-ffmpeg -hide_banner -i "$1" -c:v libvpx-vp9 -b:v "$VIDEO_BITRATE" -vf scale=1280:720 -c:a libopus -b:a "$AUDIO_BITRATE" "$1-compressed.webm"
+ffmpeg -hide_banner -y -i "$1" -c:v libx264 -preset slower -b:v "$VIDEO_BITRATE" -vf scale=1280:720 -pass 1 -an -f mp4 /dev/null && ffmpeg -hide_banner -i "$1" -c:v libx264 -preset slower -b:v "$VIDEO_BITRATE" -vf scale=1280:720 -pass 2 -c:a aac -b:a "$AUDIO_BITRATE" "$1-compressed.mp4"
+

--- a/discord-video.sh
+++ b/discord-video.sh
@@ -30,5 +30,4 @@ ADJUSTED_DURATION=$(printf "%.0f\n" "$DURATION")
 VIDEO_BITRATE=$(echo $((MAX_VIDEO_SIZE / ADJUSTED_DURATION)))
 AUDIO_BITRATE=$(echo $((MAX_AUDIO_SIZE / ADJUSTED_DURATION)))
 
-ffmpeg -hide_banner -y -i "$1" -c:v libx264 -preset slower -b:v "$VIDEO_BITRATE" -vf scale=1280:720 -pass 1 -an -f mp4 /dev/null && ffmpeg -hide_banner -i "$1" -c:v libx264 -preset slower -b:v "$VIDEO_BITRATE" -vf scale=1280:720 -pass 2 -c:a aac -b:a "$AUDIO_BITRATE" "$1-compressed.mp4"
-
+ffmpeg -hide_banner -i "$1" -c:v libvpx-vp9 -row-mt 1 -b:v "$VIDEO_BITRATE" -pix_fmt yuv420p -vf scale=1280:720 -pass 1 -an -f null /dev/null && ffmpeg -hide_banner -i "$1" -c:v libvpx-vp9 -cpu-used 3 -row-mt 1 -b:v "%VIDEO_BITRATE%" -pix_fmt yuv420p -vf scale=1280:720 -pass 2 "$1-compressed.mp4"


### PR DESCRIPTION
I've changed the script to utilize two-pass encoding and changed the encoder from libvpx-vp9 to libx264. The two-pass encoding should make it so that the encoder can optimize parts of videos with varying bitrate while staying within the average bitrate target.

EDIT: Turns out you can also do that in libvpx-vp9. I've reverted the encoder back to libvpx-vp9.
