### PR TITLE
Update 8MB -> 25MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # discord-video
-A simple bash and batch script that uses ffmpeg to compress videos to fit under 8 MB (Discord free upload limit)
+A simple bash and batch script that uses ffmpeg to compress videos to fit under 25 MB (Discord free upload limit)
 
 ## Dependencies
 * ffmpeg

--- a/discord-video.bat
+++ b/discord-video.bat
@@ -1,7 +1,7 @@
 @echo off
 
-set /A MAX_VIDEO_SIZE=60000000
-set /A MAX_AUDIO_SIZE=4000000
+set /A MAX_VIDEO_SIZE=187500000
+set /A MAX_AUDIO_SIZE=12500000
 
 if "%~1" == "" goto nofile
 

--- a/discord-video.sh
+++ b/discord-video.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# 64 000 000 bits / video length = target bitrate
+# 200 000 000 bits / video length = target bitrate
 
-MAX_VIDEO_SIZE="60000000"
-#MAX_AUDIO_SIZE="4000000"
+MAX_VIDEO_SIZE="187500000"
+#MAX_AUDIO_SIZE="12500000"
 
 # Check argument
 


### PR DESCRIPTION
Hey, thank you for writing this, your tool has been super handy the last year.

Good news: https://twitter.com/discord/status/1645522780337885184

There has been and will still be cases where I have a 26+ MB vid I want to share, so I updated the script.

I tested on my linux install with the .sh, i used a 108.7MB mp4, and these settings compressed it into a 24.7MB mp4 that successfully uploaded to my friend on my free discord account. I have not tested it on windows.