### PR TITLE
Update 25MB -> 10MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # discord-video
-A simple bash and batch script that uses ffmpeg to compress videos to fit under 25 MB (Discord free upload limit)
+A simple bash and batch script that uses ffmpeg to compress videos to fit under 10 MB (Discord free upload limit)
 
 ## Dependencies
 * ffmpeg
@@ -13,4 +13,4 @@ A simple bash and batch script that uses ffmpeg to compress videos to fit under 
 ### Windows
 ``discord-video.bat <video-file>``
 
-Output will then be a file ending with -compressed.webm
+Output will then be a file ending with -compressed.mp4

--- a/discord-video.bat
+++ b/discord-video.bat
@@ -1,7 +1,7 @@
 @echo off
 
-set /A MAX_VIDEO_SIZE=187500000
-set /A MAX_AUDIO_SIZE=12500000
+set /A MAX_VIDEO_SIZE=75000000
+set /A MAX_AUDIO_SIZE=5000000
 
 if "%~1" == "" goto nofile
 

--- a/discord-video.sh
+++ b/discord-video.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# 200 000 000 bits / video length = target bitrate
+# 80 000 000 bits / video length = target bitrate
 
-MAX_VIDEO_SIZE="187500000"
-#MAX_AUDIO_SIZE="12500000"
+MAX_VIDEO_SIZE="75000000"
+#MAX_AUDIO_SIZE="5000000"
 
 # Check argument
 


### PR DESCRIPTION
Discord recently lowered the max upload size to 10MB for free users. Following the original ratio of video:audio, I have updated it so that the produced video will be <10MB. I also noticed that the produced videos are always in .mp4 format, so changes were made to README.md to reflect that.